### PR TITLE
Enhance robustness of import

### DIFF
--- a/jinson
+++ b/jinson
@@ -37,7 +37,11 @@ class Converter:
             if 'id' in child.attrib:
                 self.bytype.setdefault(child.tag, {})[child.attrib['id']] = elementdict(child)
             else:
-                self.bytype.setdefault(child.tag, []).append(elementdict(child))
+                self.bytype.setdefault(child.tag, [])
+                if not isinstance(self.bytype[child.tag], list):
+                    print("Duplicate ID for tag : " + child.tag)
+                else:
+                    self.bytype[child.tag].append(elementdict(child))
 
     def convert(self):
         r = self.bytype
@@ -68,7 +72,9 @@ class Converter:
             p = r['Project'][i['project']]
             for a in i.get('attachments', {}).values():
                 unknown_thing = '10000'
-                a['data'] = '/'.join(('data/attachments', p['key'], unknown_thing, i['key'], a['id']))
+                issueKey = p['key'] + "-" + i['number']
+                i['key'] = issueKey
+                a['data'] = '/'.join(('data/attachments', p['key'], unknown_thing, issueKey, a['id']))
 
         # store users in a dict keyed by ApplicationUser.userKey
         users = { u['lowerUserName']: u for u in r['User'].values() }

--- a/jinson
+++ b/jinson
@@ -10,11 +10,15 @@ Options:
   --version     Show version.
 """
 
+from __future__ import print_function
 from docopt import docopt
 from datetime import datetime
 import json
 import sys
 import xml.etree.ElementTree as ET
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
 
 class Converter:
@@ -39,7 +43,7 @@ class Converter:
             else:
                 self.bytype.setdefault(child.tag, [])
                 if not isinstance(self.bytype[child.tag], list):
-                    print("Duplicate ID for tag : " + child.tag)
+                    eprint("Duplicate ID for tag : " + child.tag)
                 else:
                     self.bytype[child.tag].append(elementdict(child))
 

--- a/johill
+++ b/johill
@@ -189,7 +189,10 @@ class Converter:
             kind = item['field'].lower()
             if kind == 'assignee':
                 kind = 'owner'
-                value = self.user_email(item['newvalue'])
+                try:
+                    value = self.user_email(item['newvalue'])
+                except:
+                    value = None
             elif kind == 'summary':
                 kind = 'title'
             elif kind == 'attachment':
@@ -231,9 +234,21 @@ class Converter:
         return transactions
 
     def issue_convert(self, i):
-        reporter = self.user_email(i['reporter'])
+        
+        try:
+            reporter = self.user_email(i['reporter'])
+        except KeyError as e:
+            reporter = None
+        try:
+            assignee = self.user_email(i['assignee'])
+        except KeyError as e:
+            assignee = None
+        
         date = self.date_to_iso(i['created'])
         project = self.bytype['Project'][i['project']]['key']
+    
+        i['key'] =  project + "-" + i['number']
+
         ret = {
             'id': i['key'],
             'url': self.url(i),
@@ -241,7 +256,7 @@ class Converter:
             'creationDate': date,
             'creator': reporter,
             'description': self.markup_parse(i.get('description')),
-            'assignee': self.user_email(i['assignee']),
+            'assignee': assignee,
             'transactions': [
                 self.transaction_create(reporter, date, 'projects', { '=': [project] })
             ]


### PR DESCRIPTION
* Allow some issue fields to be missing (assignee, reporter)
* Warn only if there are collision of ID for some elements. It happens only for cloud-specific (and useless) elements
* Fix some ID generation for issue and project